### PR TITLE
ChatSpaceのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Things you may want to cover:
 * ...
 
 
+# データベース設計
+
 ## groups_usersテーブル
 
 |Column|Type|Options|
@@ -35,3 +37,42 @@ Things you may want to cover:
 - belongs_to :group
 - belongs_to :user
 
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+|email|string|null: false, unique: true|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :groups, through: :groups_users
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :users, through: :groups_users
+
+
+## Messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|
+|image|string|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
# What
chatspaceのdb設計を実装。
README.mdへ、マークダウンで見出し、テーブル、カラム、型、オプション、アソシエーションを記載。

# Why
chatspace実装のため。db設計は必須なので追加。