### PR TITLE
メッセージ送信機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,6 @@ gem 'erb2haml'
 gem 'font-awesome-sass'
 
 gem 'devise'
+
+gem 'carrierwave'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,11 +38,20 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (7.1.4)
     bcrypt (3.1.13)
     bindex (0.8.1)
     builder (3.2.3)
     byebug (11.0.1)
+    carrierwave (2.0.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -83,6 +92,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.9.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.13, < 3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
@@ -98,6 +110,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mimemagic (0.3.3)
+    mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
@@ -106,6 +120,7 @@ GEM
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (0.6.3)
@@ -140,6 +155,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.16)
+      ffi (~> 1.9)
     ruby_parser (3.14.1)
       sexp_processor (~> 4.9)
     sass (3.7.4)
@@ -194,6 +211,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   erb2haml
@@ -202,6 +220,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,12 +20,12 @@
  @import "./font-awesome";
  @import "user";
  @import "flash";
- @import "group";
+//  @import "group"
  
 * {
   box-sizing: border-box;
 }
-
+  
 .chat-side {
   width: 300px;
   color: white;
@@ -156,17 +156,26 @@
     background-color: #fafafa;
     overflow: scroll;
   }
+}
   .form {
+    width: calc(100vw-300px);
     height: 90px;
     padding: 20px 40px;
     background-color: #ddd;
     color: #000;
     font: 16px; 
     form {
+
+      .input {
+        width: calc(100% - 150px);
+        display: block;
+      }
       display: flex;
+      width: 100%;
+
       .input-box {
         position: relative;
-        width: 100%;
+        // width: 100%;
         &__image {
           font-size: 1.3rem;
           position: absolute;
@@ -203,4 +212,3 @@
       }
     }
   }
-}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,7 +12,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     if @group.save
-      redirect_to root_path, notice: 'グループを作成しました'
+      redirect_to group_messages_path(@group), notice: 'グループを作成しました'
     else
       render :new
     end
@@ -23,7 +23,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,29 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
+  end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,15 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
+  
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,8 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+
+  mount_uploader :image, ImageUploader
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,48 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  process resize_to_fit: [800,800]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,26 +1,23 @@
 .chat-group-form
   %h1 チャットグループ編集
   = render partial: 'form', locals: { group: @group }
-  %form
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+  -# %form
+  -#   .chat-group-form__errors
+  -#     %h2
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#       %label.chat-group-form__label{for: "chat_group_name"} グループ名
+  -#     .chat-group-form__field--right
+  -#       %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+  -#   .chat-group-form__field
+  -#     / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#       %label.chat-group-form__label チャットメンバー
+  -#     .chat-group-form__field--right
+  -#       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+  -#       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#     .chat-group-form__field--right
+  -#       %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,28 +1,28 @@
 .chat-group-form
   %h1 新規チャットグループ
   = render 'form', { group: @group }
-  = form_for @group do |f|
-    - if @group.errors.any?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label :name, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label "チャットメンバー", class: "chat-group-form__label"
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit class: 'chat-group-form__action-btn'
+  -# = form_for @group do |f|
+  -#   - if @group.errors.any?
+  -#     .chat-group-form__errors
+  -#       %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+  -#       %ul
+  -#         - @group.errors.full_messages.each do |message|
+  -#           %li= message
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#       = f.label :name, class: 'chat-group-form__label'
+  -#     .chat-group-form__field--right
+  -#       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  -#   .chat-group-form__field
+  -#     / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#       = f.label "チャットメンバーを追加", class: "chat-group-form__label"
+  -#     .chat-group-form__field--right
+  -#       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+  -#       = f.collection_check_boxes :user_ids, User.all, :id, :name
+  -#       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+  -#   .chat-group-form__field
+  -#     .chat-group-form__field--left
+  -#     .chat-group-form__field--right
+  -#       = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,28 +1,23 @@
 .chat-main
   .main-header
     .main-header__left-box
-      %h2.main-header__left-box__current-group{"data-group_id": "6901"}
-        jump_comics
+      %h2.main-header__left-box__current-group
+        = @group.name
       %ul.main-header__left-box__member-list
         Member：
-        %li.main-header__left-box__member-list__member yuyu
-    =link_to "#", class:"a" do
+        %li.main-header__left-box__member-list__member
+          - @group.users.each do |g|
+            = g.name
+    =link_to "edit", class:"a" do
       .main-header__edit-btn Edit
   .messages
+    = render @messages
   
   .form
-    %form#new_message.new_message{"accept-charset": "UTF-8", action: "/groups/7442/messages", enctype: "multipart/form-data", method: "post"}
-      %input{name: "utf8", type: "hidden", value: "✓"}/
-      %input{name: "authenticity_token", type: "hidden", value: "7vIZxp6PpOiKcEY0mnCWZmEMtM1Cas97eGz+rmDY9yQ3MQ1bNgl4hjzkcd58TR0PdqCr5T6yLCnBL3WNcoRHZg=="}/
+    = form_for [@group, @message] do |f|
+      = f.text_field :content, class: 'input', placeholder: 'type a message'
       .input-box
-        %input#message_content.input-box__text{name: "message[content]", placeholder: "type a message", type: "text"}/
-
-        %label.input-box__image{for: "message_image"}
-          %i.fa.fa-image
-          %input#message_image.input-box__image__file{name: "message[image]", type: "file"}/
-
-      %input.submit-btn{"data-disable-with": "Send", name: "commit", type: "submit", value: "Send"}/
-
-
-
-      
+        = f.label :image, class: 'input-box__image' do
+          = icon('fas', 'image', class: 'icon')
+          = f.file_field :image, class: 'input-box__image__file'
+      = f.submit 'Send', class: 'submit-btn'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,11 @@
+.message
+  .upper-message
+    .upper-message__user-name
+      = message.user.name
+    .upper-message__date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  .lower-message
+    - if message.content.present?
+      %p.lower-message__content
+        = message.content
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -17,4 +17,5 @@
           .group-name
             = group.name
           .latest-message
-            メッセージはまだありません。
+          = group.show_last_message
+

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,4 +1,3 @@
-
 .wrapper
   = render "messages/side_bar"
-  -# = render "messages/main_chat"
+  = render "messages/main_chat"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
 
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
-    resources :messages, only: [:index]
+    resources :messages, only: [:index, :create]
   end
 end

--- a/db/migrate/20191205014418_create_messages.rb
+++ b/db/migrate/20191205014418_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191204013646) do
+ActiveRecord::Schema.define(version: 20191205014418) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 20191204013646) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -44,4 +55,6 @@ ActiveRecord::Schema.define(version: 20191204013646) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
#WHAT
メッセージ送信機能を追加
バリデーション追加
メッセージ送信の失敗時の処理を実装

グループにメッセージを表示
サイドバーに最新のメッセージを表示
ヘッダーにグループ名とユーザー名が表示されるように実装
グループ編集ページへのリンクを設置

#WHY
チャット機能に必要な内容であるため